### PR TITLE
Fix perl dependency on Digest::SHA1

### DIFF
--- a/dnssec_monitor.pl
+++ b/dnssec_monitor.pl
@@ -37,7 +37,7 @@ use Net::DNS 0.49;
 use Net::DNS::SEC 0.12;
 
 use Crypt::OpenSSL::Random qw(random_bytes);
-use Digest::SHA1 qw(sha1);
+use Digest::SHA qw(sha1);
 use Digest::BubbleBabble qw(bubblebabble);
 
 use dnssec_monitor;

--- a/nagios_dnssec.pl
+++ b/nagios_dnssec.pl
@@ -31,7 +31,7 @@ use warnings;
 use strict;
 
 use Crypt::OpenSSL::Random qw(random_bytes);
-use Digest::SHA1 qw(sha1);
+use Digest::SHA qw(sha1);
 use Digest::BubbleBabble qw(bubblebabble);
 
 use Pod::Usage;


### PR DESCRIPTION
The Debian package libdigest-sha-perl installs the required module to Digest::SHA as opposed to Digest::SHA1.  Fix the include in the scripts to reflect this.
